### PR TITLE
openssl: bump to 1.1.1g (#4415)

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=f
+PKG_BUGFIX:=g
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -19,12 +19,13 @@ PKG_BUILD_PARALLEL:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
-	http://ftp.fi.muni.cz/pub/openssl/source/ \
-	http://ftp.linux.hr/pub/openssl/source/ \
+	https://mirrors.cloud.tencent.com/openssl/source/ \
+	https://mirrors.cloud.tencent.com/openssl/source/old/$(PKG_BASE)/ \
+	https://ftp.fi.muni.cz/pub/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
-	http://www.openssl.org/source/ \
-	http://www.openssl.org/source/old/$(PKG_BASE)/
-PKG_HASH:=186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35
+	https://www.openssl.org/source/ \
+	https://www.openssl.org/source/old/$(PKG_BASE)/
+PKG_HASH:=ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Fixes NULL dereference in SSL_check_chain() for TLS 1.3, marked with
high severity, assigned CVE-2020-1967.

Ref: https://www.openssl.org/news/secadv/20200421.txt

Cherry-pick from openwrt/openwrt@3773ae1.
Also add mirror for mainland China user in this commit.

Signed-off-by: Petr Štetiar <ynezz@true.cz>
Signed-off-by: CN_SZTL <cnsztl@project-openwrt.eu.org>

Co-authored-by: Petr Štetiar <ynezz@true.cz>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
